### PR TITLE
Add root to the workspace but ignore subfolders

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "files.exclude": {
+    "backend/": true,
+    "frontend/": true
+  }
+}

--- a/secret.code-workspace
+++ b/secret.code-workspace
@@ -1,10 +1,14 @@
 {
   "folders": [
-	{
-		"path": "frontend"
-	},
-	{
-		"path": "backend"
-	}
-]
+    {
+      "name": "root",
+      "path": "."
+    },
+    {
+      "path": "frontend"
+    },
+    {
+      "path": "backend"
+    }
+  ]
 }


### PR DESCRIPTION
Add the root folder to the workspace, but ignore subfolders. This enables us edit files at the root of the repo (such as the README.md file), while keeping all the benefits of our multi-root workspace, and without having the frontend and backend folders show up in the root folder.

<img width="1200" alt="image" src="https://github.com/shadanan/secret-cipher/assets/361429/e507b06a-de2e-4832-803d-a4ba2cf1be3e">